### PR TITLE
Allow compilation & usage when not using unimplemented fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Zig Chrono
 
 A Zig port of the Rust crate [`chrono`][]. Built with Zig version
-`0.8.0-dev.1028+287f640cc`.
+`0.9.0`.
 
 [`chrono`]: https://github.com/chronotope/chrono

--- a/src/timezone.zig
+++ b/src/timezone.zig
@@ -68,6 +68,7 @@ pub const Fixed = struct {
 pub const TZif = struct {
     timezone: TimeZone = .{
         .utcToLocalFn = utcToLocal,
+        .timezoneToUtcFn = timezoneToUtc,
     },
     tzif: tzif.TimeZone,
 
@@ -88,18 +89,34 @@ pub const TZif = struct {
         };
         return conversion.timestamp;
     }
+
+    fn timezoneToUtc(timezone: *const TimeZone, timestamp: i64) i64 {
+        const this = @fieldParentPtr(@This(), "timezone", timezone);
+        const conversion = this.tzif.localTimeToUTC(timestamp) orelse {
+            std.debug.panic("TZif file does not specify TimeZone", .{});
+        };
+        return conversion.timestamp;
+    }
 };
 
 pub const Posix = struct {
     timezone: TimeZone = .{
         .utcToLocalFn = utcToLocal,
+        .timezoneToUtcFn = timezoneToUtc,
     },
+
     tz: posix.TZ,
 
     fn utcToLocal(timezone: *const TimeZone, timestamp: i64) i64 {
         const this = @fieldParentPtr(@This(), "timezone", timezone);
         const offset_res = this.tz.offset(timestamp);
         return timestamp + offset_res.offset;
+    }
+
+    fn timezoneToUtc(timezone: *const TimeZone, timestamp: i64) i64 {
+        const this = @fieldParentPtr(@This(), "timezone", timezone);
+        const offset_res = this.tz.offset(timestamp);
+        return timestamp - offset_res.offset;
     }
 };
 

--- a/src/timezone/tzif.zig
+++ b/src/timezone/tzif.zig
@@ -102,7 +102,8 @@ pub const TimeZone = struct {
     pub fn localTimeToUTC(this: @This(), localtime: i64) ?ConversionResult {
         _ = this;
         _ = localtime;
-        @compileError("Unimplemented");
+        std.debug.panic("Unimplemented", .{});
+        return null;
     }
 };
 


### PR DESCRIPTION
Some change has introduced a compilation error on Linux. These changes fix that by defining some fns and emitting debug panics from the unimplemented tzif implementation instead of compile errors. This allows one to use the other functions in the library.