### PR TITLE
No optionals; only errors

### DIFF
--- a/src/datetime.zig
+++ b/src/datetime.zig
@@ -29,11 +29,11 @@ pub const DateTime = struct {
         return .{ .datetime = datetime, .timezone = tz };
     }
 
-    pub fn local(localDatetime: NaiveDateTime, tz: *const TimeZone) @This() {
+    pub fn local(localDatetime: NaiveDateTime, tz: *const TimeZone) !@This() {
         const timezone_timestamp = localDatetime.signed_duration_since(EPOCH);
         const timestamp = tz.timezoneToUtc(timezone_timestamp);
-        return .{
-            .datetime = NaiveDateTime.from_timestamp(timestamp, 0).?,
+        return @This(){
+            .datetime = try NaiveDateTime.from_timestamp(timestamp, 0),
             .timezone = tz,
         };
     }

--- a/src/format.zig
+++ b/src/format.zig
@@ -174,8 +174,8 @@ test "format naive datetimes with parts api" {
     };
 
     const cases = [_]Case{
-        .{ .datetime = NaiveDate.ymd(2021, 02, 18).?.hms(17, 00, 00).?, .expected_string = "2021-02-18 17:00:00" },
-        .{ .datetime = NaiveDate.ymd(1970, 01, 01).?.hms(0, 0, 0).?, .expected_string = "1970-01-01 00:00:00" },
+        .{ .datetime = try NaiveDateTime.ymd_hms(2021, 02, 18, 17, 00, 00), .expected_string = "2021-02-18 17:00:00" },
+        .{ .datetime = try NaiveDateTime.ymd_hms(1970, 01, 01, 0, 0, 0), .expected_string = "1970-01-01 00:00:00" },
     };
 
     const parts = try parseFormatAlloc(std.testing.allocator, "%Y-%m-%d %H:%M:%S");
@@ -198,8 +198,8 @@ test "format naive datetimes with format string api" {
     };
 
     const cases = [_]Case{
-        .{ .datetime = NaiveDate.ymd(2021, 02, 18).?.hms(17, 00, 00).?, .expected_string = "2021-02-18 17:00:00" },
-        .{ .datetime = NaiveDate.ymd(1970, 01, 01).?.hms(0, 0, 0).?, .expected_string = "1970-01-01 00:00:00" },
+        .{ .datetime = try NaiveDateTime.ymd_hms(2021, 02, 18, 17, 00, 00), .expected_string = "2021-02-18 17:00:00" },
+        .{ .datetime = try NaiveDateTime.ymd_hms(1970, 01, 01, 0, 0, 0), .expected_string = "1970-01-01 00:00:00" },
     };
 
     for (cases) |case| {
@@ -299,7 +299,7 @@ pub fn parseNaiveDateTime(comptime format: []const u8, dtString: []const u8) !Na
     std.debug.assert(hour != null);
     std.debug.assert(minute != null);
 
-    return NaiveDate.ymd(year.?, month.?, day.?).?.hms(hour.?, minute.?, second orelse 0).?;
+    return NaiveDateTime.ymd_hms(year.?, month.?, day.?, hour.?, minute.?, second orelse 0);
 }
 
 pub const Parsed = struct {
@@ -507,8 +507,8 @@ test "comptime parse with comptime format string" {
     };
 
     const cases = [_]Case{
-        .{ .string = "2021-02-18 17:00:00", .expected_datetime = NaiveDate.ymd(2021, 02, 18).?.hms(17, 00, 00).? },
-        .{ .string = "1970-01-01 00:00:00", .expected_datetime = NaiveDate.ymd(1970, 01, 01).?.hms(0, 0, 0).? },
+        .{ .string = "2021-02-18 17:00:00", .expected_datetime = try NaiveDateTime.ymd_hms(2021, 02, 18, 17, 00, 00) },
+        .{ .string = "1970-01-01 00:00:00", .expected_datetime = try NaiveDateTime.ymd_hms(1970, 01, 01, 0, 0, 0) },
     };
 
     for (cases) |case| {

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -9,6 +9,14 @@ pub const duration = @import("./duration.zig");
 
 pub const IsoWeek = @import("./IsoWeek.zig");
 
+pub const NaiveDate = date.NaiveDate;
+pub const NaiveTime = time.NaiveTime;
+pub const NaiveDateTime = datetime.NaiveDateTime;
+
+pub const DateTime = datetime.DateTime;
+
+pub const EPOCH = NaiveDateTime.ymd_hms(1970, 01, 01, 0, 0, 0) catch unreachable;
+
 pub const Weekday = enum(u3) {
     mon = 0,
     tue = 1,

--- a/src/timezone/wasm.zig
+++ b/src/timezone/wasm.zig
@@ -13,7 +13,7 @@ pub fn utcToLocal(timestamp: i64) i64 {
 pub fn localToUtc(timestamp: i64) i64 {
     var str_buf: [100]u8 = undefined;
 
-    const datetime = NaiveDateTime.from_timestamp(timestamp, 0).?;
+    const datetime = NaiveDateTime.from_timestamp(timestamp, 0) catch unreachable;
     const str = std.fmt.bufPrint(&str_buf, "{}", .{datetime.formatted("%Y-%m-%dT%H:%M:%S")}) catch unreachable;
 
     return datetimeStrToUTCTimestamp(str.ptr, str.len);


### PR DESCRIPTION
Change functions that used to return an optional to return an error. This is a breaking change. Not sure if this is better? Looking for feedback.

@hazeycode as you made issue #4, what do you think about these changes? 